### PR TITLE
refactor: preprocess input in run fn

### DIFF
--- a/src/2024/01/part1.ts
+++ b/src/2024/01/part1.ts
@@ -1,10 +1,9 @@
-export default function solution(input: string) {
+export default function solution({ lines }: Input) {
+  let result = 0;
   const list1: number[] = [];
   const list2: number[] = [];
 
-  const rows = input.split("\n").filter((v) => v != "").map((w) =>
-    w.split(/\s+/)
-  );
+  const rows = lines.map((w) => w.split(/\s+/));
   rows.forEach((row) => {
     list1.push(parseInt(row[0]));
     list2.push(parseInt(row[1]));
@@ -13,7 +12,6 @@ export default function solution(input: string) {
   list1.sort((a, b) => a - b);
   list2.sort((a, b) => a - b);
 
-  let result = 0;
   list1.forEach((item, index) => {
     const diff = Math.abs(list2[index] - item);
     result += diff;
@@ -23,8 +21,7 @@ export default function solution(input: string) {
 
 export const tests = [
   [
-    `
-3   4
+    `3   4
 4   3
 2   5
 1   3

--- a/src/2024/01/part2.ts
+++ b/src/2024/01/part2.ts
@@ -1,10 +1,9 @@
-export default function solution(input: string) {
+export default function solution({ lines }: Input) {
+  let result = 0;
   const list1: number[] = [];
   const list2: number[] = [];
 
-  const rows = input.split("\n").filter((v) => v != "").map((w) =>
-    w.split(/\s+/)
-  );
+  const rows = lines.map((w) => w.split(/\s+/));
   rows.forEach((row) => {
     list1.push(parseInt(row[0]));
     list2.push(parseInt(row[1]));
@@ -15,7 +14,6 @@ export default function solution(input: string) {
   list1.uniques().forEach((item) => {
     amounts[item] = list2.filter((_i) => _i == item).length;
   });
-  let result = 0;
   list1.forEach((item) => {
     result += item * amounts[item];
   });

--- a/src/2024/02/part1.ts
+++ b/src/2024/02/part1.ts
@@ -1,7 +1,5 @@
-export default function solution(input: string) {
-  const rows = input.split("\n").filter((v) => v != "").map((w) =>
-    w.split(" ").map((num) => parseInt(num))
-  );
+export default function solution({ lines }: Input) {
+  const rows = lines.map((w) => w.split(" ").map(Number));
   const safe_rows = rows.filter((row) => {
     const diffs = row.map((item, index) => item - row[index - 1]);
     diffs.shift();

--- a/src/2024/02/part2.ts
+++ b/src/2024/02/part2.ts
@@ -1,7 +1,5 @@
-export default function solution(input: string) {
-  const rows = input.split("\n").filter((v) => v != "").map((w) =>
-    w.split(" ").map((num) => parseInt(num))
-  );
+export default function solution({ lines }: Input) {
+  const rows = lines.map((w) => w.split(" ").map(Number));
   const is_row_safe = (row: number[]) => {
     const diffs = row.map((item, index) => item - row[index - 1]);
     diffs.shift();

--- a/src/2024/03/part1.ts
+++ b/src/2024/03/part1.ts
@@ -1,13 +1,13 @@
-export default function solution(input: string) {
-  const pattern = /mul\([0-9]+,[0-9]+\)/g;
+export default function solution({ input }: Input) {
+  let result = 0;
+  const pattern = /mul\([\d]+,[\d]+\)/g;
   const found = input.match(pattern);
-  let sum = 0;
   found?.forEach((item) => {
-    const numbers = item.match(/[0-9]+/g)?.map((i) => parseInt(i));
+    const numbers = item.match(/[\d]+/g)?.map(Number);
     const mult = [...numbers!].reduce((acc, cur) => acc * cur);
-    sum += mult;
+    result += mult;
   });
-  return sum;
+  return result;
 }
 
 export const tests = [

--- a/src/2024/03/part2.ts
+++ b/src/2024/03/part2.ts
@@ -1,6 +1,6 @@
-export default function solution(input: string) {
-  const pattern = /do\(\)|don\'t\(\)|mul\([0-9]+,[0-9]+\)/g;
-  let sum = 0;
+export default function solution({ input }: Input) {
+  const pattern = /do\(\)|don\'t\(\)|mul\([\d]+,[\d]+\)/g;
+  let result = 0;
   let do_mul = true;
   input.match(pattern)!.forEach((task) => {
     if (task == "do()") {
@@ -9,12 +9,12 @@ export default function solution(input: string) {
       do_mul = false;
     } else {
       if (do_mul) {
-        const numbers = task.match(/[0-9]+/g)?.map(Number)!;
-        sum += [...numbers].reduce((a, b) => a * b);
+        const numbers = task.match(/[\d+]+/g)?.map(Number)!;
+        result += [...numbers].reduce((a, b) => a * b);
       }
     }
   });
-  return sum;
+  return result;
 }
 
 export const tests = [

--- a/utils/prep.ts
+++ b/utils/prep.ts
@@ -7,13 +7,7 @@ const DATE = Deno.args[1] ?? new Date().getDate();
 const PART = Deno.args[2] ?? 1;
 const SCHEDULED = !!Deno.args[3];
 const formattedDate = `0${DATE}`.slice(-2);
-const TEMPLATE = `export default function solution(input: string) {
-    return;
-}
-
-export const tests = [
-    ["", ],
-]`;
+const TEMPLATE = Deno.readTextFileSync("./utils/template.ts");
 
 if (!SESSION) {
   throw new Error("Make sure you have a .env file with SESSION=<your token>");

--- a/utils/run.ts
+++ b/utils/run.ts
@@ -1,5 +1,13 @@
 import "../src/utils/index.ts";
 
+declare global {
+  type Input = {
+    input: string;
+    lines: string[];
+    grid: string[][];
+  };
+}
+
 export async function run(
   currentYear: string,
   currentDate: string,
@@ -14,11 +22,12 @@ export async function run(
     )
       .then((c) => new TextDecoder("utf-8").decode(c));
   }
-
+  const lines = input?.split("\n");
+  const grid = lines?.map((line) => line.split(""));
   const { default: solution } = await import(
     `../src/${currentYear}/${formattedDate}/part${part}.ts?t=${Date.now()}`
   );
-  const attempt = solution(input);
+  const attempt = solution({ input, grid, lines });
 
   return attempt;
 }

--- a/utils/run.ts
+++ b/utils/run.ts
@@ -22,7 +22,7 @@ export async function run(
     )
       .then((c) => new TextDecoder("utf-8").decode(c));
   }
-  const lines = input?.split("\n");
+  const lines = input?.split("\n").filter((w) => w !== "");
   const grid = lines?.map((line) => line.split(""));
   const { default: solution } = await import(
     `../src/${currentYear}/${formattedDate}/part${part}.ts?t=${Date.now()}`

--- a/utils/template.ts
+++ b/utils/template.ts
@@ -1,0 +1,9 @@
+export default function solution({ input }: Input) {
+  let result = 0;
+
+  return result;
+}
+
+export const tests = [
+  ["", 0],
+];


### PR DESCRIPTION
Preprocess the input.txt In the `run` function by splitting the lines, and creating a grid by splitting each line by chars, might be useful for the following days.
Also add a global `Input` type that can be used in the `solution` functions, and move the template to its own file that can be read by the `prep` task.

I also ran
```bash
find src/2024 -type f -name "*.ts" -exec sed -i 's/solution(input: string)/solution({ input }: Input)/g' {} +
```